### PR TITLE
Add dynamic music status

### DIFF
--- a/_includes/about/about.html
+++ b/_includes/about/about.html
@@ -22,6 +22,7 @@
           {{ interest.name }}{% if forloop.last != true %}, {% endif %}
           {% endfor %}
         </p>
+        <p class="lead" id="music-status"></p>
         <hr class="my-4">
         <div class="row">
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -44,6 +44,7 @@
   <body>
   {{ content }}
   <script src="{{ site.baseurl }}/js/profile-icons.js"></script>
+  <script src="{{ site.baseurl }}/js/music-status.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/js/music-status.js
+++ b/js/music-status.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', function() {
+  var statusEl = document.getElementById('music-status');
+  if (!statusEl) return;
+  statusEl.innerHTML = '<div class="spinner-border spinner-border-sm me-2" role="status"><span class="visually-hidden">Loading...</span></div> Loading...';
+
+  fetch('https://music-api.tomhcy.workers.dev/')
+    .then(function(res) { return res.json(); })
+    .then(function(data) {
+      if (!data.success) {
+        statusEl.textContent = 'Not Listening To Anything :(';
+        return;
+      }
+      var prefix = data.isPlaying ? 'Now Listening To' : 'Recently Listened To';
+      var link = '<a href="' + data.songUrl + '" target="_blank">' + data.title + '</a>';
+      statusEl.innerHTML = prefix + ': ' + link + ' by ' + data.artist + ' on ' + data.source + '.';
+    })
+    .catch(function() {
+      statusEl.textContent = 'Not Listening To Anything :(';
+    });
+});

--- a/js/music-status.js
+++ b/js/music-status.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', function() {
     .then(function(res) { return res.json(); })
     .then(function(data) {
       if (!data.success) {
+        console.error('Music API Error:', data.error);
         statusEl.textContent = 'Not Listening To Anything :(';
         return;
       }


### PR DESCRIPTION
## Summary
- show current track info on About page
- fetch data from music API in a new script
- load the script on all pages

## Testing
- `bundle exec jekyll build` *(fails: Could not find jekyll-4.3.4 et al.)*

------
https://chatgpt.com/codex/tasks/task_e_686b5aa3ad388331a526651c1bf9f531